### PR TITLE
Refresh token/Globus SDK Authorizers support

### DIFF
--- a/examples/config_complex.py
+++ b/examples/config_complex.py
@@ -15,8 +15,22 @@ class MyTokenStorage(object):
 
     def write_tokens(self, tokens):
         """
-        Write tokens to disk. `tokens` is a Globus SDK object:
-        globus_sdk.auth.token_response.OAuthTokenResponse
+        Write tokens to disk. 'tokens' above will be in this format:
+        {
+            'auth.globus.org': {
+                'scope': 'openid profile email',
+                'access_token': '<token>',
+                'refresh_token': None,
+                'token_type': 'Bearer',
+                'expires_at_seconds': DEFAULT_EXPIRE,
+                'resource_server': 'auth.globus.org'
+            },
+            <More Token Dicts>
+        }
+        Some configs, like ConfigParser on python 2.7, do not allow nested
+        sections. In that case you can use these tools:
+
+        from native_client.token_storage import flat_pack, flat_unpack
         """
         with open(self.FILENAME, 'w+') as fh:
             json.dump(tokens.by_resource_server, fh, indent=2)

--- a/native_login/exc.py
+++ b/native_login/exc.py
@@ -23,4 +23,12 @@ class TokensExpired(LoadError):
     """
     Tokens have expired
     """
-    pass
+    def __init__(self, *args, resource_servers=(), **kwargs):
+        super(TokensExpired, self).__init__(*args, **kwargs)
+        self.resource_servers = resource_servers
+
+    def __str__(self):
+        return '{} {}'.format(
+            super(TokensExpired, self).__str__(),
+            ', '.join(self.resource_servers)
+        )

--- a/native_login/token_storage/configparser_token_storage.py
+++ b/native_login/token_storage/configparser_token_storage.py
@@ -31,7 +31,7 @@ class ConfigParserTokenStorage(object):
 
     def write_tokens(self, tokens):
         config = self.load()
-        for name, value in flat_pack(tokens.by_resource_server).items():
+        for name, value in flat_pack(tokens).items():
             config.set(self.section, name, value)
         self.save(config)
 

--- a/native_login/token_storage/json_token_storage.py
+++ b/native_login/token_storage/json_token_storage.py
@@ -12,7 +12,7 @@ class JSONTokenStorage(object):
 
     def write_tokens(self, tokens):
         with open(self.filename, 'w+') as fh:
-            json.dump(tokens.by_resource_server, fh, indent=2)
+            json.dump(tokens, fh, indent=2)
 
     def read_tokens(self):
         if not os.path.exists(self.filename):

--- a/native_login/token_storage/storage_tools.py
+++ b/native_login/token_storage/storage_tools.py
@@ -5,11 +5,11 @@ from native_login.exc import TokensExpired, ScopesMismatch
 
 def check_expired(tokens):
     expired = [
-        time.time() >= t['expires_at_seconds']
-        for t in tokens.values()
+        rs for rs, tset in tokens.items()
+        if time.time() >= tset['expires_at_seconds']
     ]
-    if any(expired):
-        raise TokensExpired()
+    if expired:
+        raise TokensExpired(resource_servers=expired)
 
 
 def check_scopes(tokens, requested_scopes):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from native_login import NativeClient, ConfigParserTokenStorage
+
+
+@pytest.fixture
+def live_client():
+    storage = ConfigParserTokenStorage(filename='integ_testing_tokens.cfg')
+    client = NativeClient(client_id='7414f0b4-7d05-4bb6-bb00-076fa3f17cf5',
+                          token_storage=storage,
+                          default_scopes=['openid'])
+    return client

--- a/tests/integration/test_client_refresh.py
+++ b/tests/integration/test_client_refresh.py
@@ -1,0 +1,33 @@
+
+"""
+The most basic usage automatically saves and loads tokens, and provides
+a local server for logging in users.
+"""
+import pytest
+
+
+@pytest.mark.skip(reason='Integration test')
+def test_refresh(live_client):
+    tokens = live_client.login(refresh_tokens=True)
+    for tset in tokens.values():
+        tset['expires_at_seconds'] = 0
+    live_client.save_tokens(tokens)
+    live_client.load_tokens()
+    for old_t, new_t in (tokens.values(), live_client.load_tokens().values()):
+        assert old_t['access_token'] != new_t['access_token']
+
+
+@pytest.mark.skip(reason='Integration test')
+def test_authorizer_refresh_hook(live_client):
+    tokens = live_client.login(refresh_tokens=True)
+    old_access_token = tokens['auth.globus.org']['access_token']
+
+    auth = live_client.get_authorizers()['auth.globus.org']
+    old_auth_tok = auth.access_token
+    auth.expires_at = 0
+    auth.check_expiration_time()
+
+    saved_token = live_client.load_tokens()['auth.globus.org']['access_token']
+    assert old_auth_tok != auth.access_token
+    assert saved_token == auth.access_token
+    assert saved_token != old_access_token

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,12 @@
 import pytest
 import webbrowser
+import time
 from copy import deepcopy
 from .mocks import MemoryStorage, MOCK_TOKEN_SET
-from native_login import NativeClient, client
+from native_login import NativeClient
 import six
+
+import globus_sdk
 
 try:
     from unittest.mock import Mock
@@ -36,10 +39,20 @@ def expired_tokens_with_refresh(mock_expired_tokens):
 
 
 @pytest.fixture
-def mock_refresh_token_authorizer(monkeypatch):
-    monkeypatch.setattr(client,
-                        'RefreshTokenAuthorizer',
-                        Mock())
+def mock_refresh_token_authorizer(monkeypatch, mock_tokens,
+                                  mock_token_response):
+    def get_new_access_token(self):
+        self.access_token = '<Refreshed Access Token>'
+        self._set_expiration_time(int(time.time()) + 60 * 60 * 48)
+        if self.on_refresh is not None:
+            # We can't fetch real tokens, so make some up!
+            custom_tokens = {'example.on.refresh.success':
+                             mock_tokens['resource.server.org']}
+            mock_token_response.tokens = custom_tokens
+            self.on_refresh(mock_token_response)
+    monkeypatch.setattr(globus_sdk.RefreshTokenAuthorizer,
+                        '_get_new_access_token',
+                        get_new_access_token)
 
 
 @pytest.fixture
@@ -67,11 +80,11 @@ def mock_revoke(monkeypatch):
 def mock_token_response(monkeypatch, mock_tokens):
     class GlobusSDKTokenResponse:
         def __init__(self, *args, **kwargs):
-            pass
+            self.tokens = mock_tokens
 
         @property
         def by_resource_server(self):
-            return mock_tokens
+            return self.tokens
 
     monkeypatch.setattr(NativeClient, 'oauth2_exchange_code_for_tokens',
                         GlobusSDKTokenResponse)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import webbrowser
 from copy import deepcopy
 from .mocks import MemoryStorage, MOCK_TOKEN_SET
-from native_login import NativeClient
+from native_login import NativeClient, client
 import six
 
 try:
@@ -19,6 +19,27 @@ def mem_storage():
 @pytest.fixture
 def mock_tokens():
     return deepcopy(MOCK_TOKEN_SET)
+
+
+@pytest.fixture
+def mock_expired_tokens(mock_tokens):
+    for tset in mock_tokens.values():
+        tset['expires_at_seconds'] = 0
+    return mock_tokens
+
+
+@pytest.fixture
+def expired_tokens_with_refresh(mock_expired_tokens):
+    for tset in mock_expired_tokens.values():
+        tset['refresh_token'] = '<Mock Refresh Token>'
+    return mock_expired_tokens
+
+
+@pytest.fixture
+def mock_refresh_token_authorizer(monkeypatch):
+    monkeypatch.setattr(client,
+                        'RefreshTokenAuthorizer',
+                        Mock())
 
 
 @pytest.fixture

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -1,6 +1,11 @@
 import time
 import os
 
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 CONFIGPARSER_VALID_CFG = os.path.join(DATA_PATH, 'configparser_valid.cfg')
 

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -1,10 +1,6 @@
 import time
 import os
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 CONFIGPARSER_VALID_CFG = os.path.join(DATA_PATH, 'configparser_valid.cfg')

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 import pytest
+from globus_sdk import AccessTokenAuthorizer, RefreshTokenAuthorizer
 
 from native_login.client import NativeClient
 from native_login.token_storage.configparser_token_storage import (
@@ -9,8 +10,6 @@ from native_login.local_server import LocalServerCodeHandler
 from native_login.code_handler import InputCodeHandler
 from native_login.exc import LoadError, ScopesMismatch, TokensExpired
 from native_login.version import __version__
-
-from .mocks import Mock
 
 
 def test_version_sanity():
@@ -141,7 +140,20 @@ def test_client_token_refresh_with_tokens(expired_tokens_with_refresh,
     cli = NativeClient(client_id=str(uuid4()), token_storage=None)
     tokens = cli.refresh_tokens(expired_tokens_with_refresh)
     for tset in tokens.values():
-        assert isinstance(tset['access_token'], Mock)
+        assert tset['access_token'] == '<Refreshed Access Token>'
+
+
+def test_client_get_authorizers(mock_tokens,
+                                mock_refresh_token_authorizer,
+                                mem_storage):
+    mock_tokens['resource.server.org']['refresh_token'] = '<Refresh Token>'
+    mem_storage.tokens = mock_tokens
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    for rs, authorizer in cli.get_authorizers().items():
+        if rs == 'resource.server.org':
+            assert isinstance(authorizer, RefreshTokenAuthorizer)
+        else:
+            assert isinstance(authorizer, AccessTokenAuthorizer)
 
 
 def test_client_load_auto_refresh(expired_tokens_with_refresh, mem_storage,
@@ -150,7 +162,21 @@ def test_client_load_auto_refresh(expired_tokens_with_refresh, mem_storage,
     cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
     tokens = cli.load_tokens()
     for tset in tokens.values():
-        assert isinstance(tset['access_token'], Mock)
+        assert tset['access_token'] == '<Refreshed Access Token>'
+
+
+def test_authorizer_refresh_hook(mock_tokens,
+                                 mock_refresh_token_authorizer,
+                                 mem_storage):
+    mock_tokens['resource.server.org']['refresh_token'] = '<Refresh Token>'
+    mem_storage.tokens = mock_tokens
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    rs_auth = cli.get_authorizers()['resource.server.org']
+    rs_auth.expires_at = 0
+    rs_auth.check_expiration_time()
+
+    tokens = cli.load_tokens()
+    assert 'example.on.refresh.success' in tokens.keys()
 
 
 def test_client_when_cannot_refresh(mock_expired_tokens, mem_storage,

--- a/tests/unit/test_storage_classes.py
+++ b/tests/unit/test_storage_classes.py
@@ -11,7 +11,7 @@ from native_login import (ConfigParserTokenStorage, JSONTokenStorage,
 from .mocks import MOCK_TOKEN_SET, CONFIGPARSER_VALID_CFG
 
 
-def test_json_token_storage(mock_token_response, mock_revoke, monkeypatch):
+def test_json_token_storage(mock_tokens, mock_revoke, monkeypatch):
     cli = NativeClient(client_id=str(uuid.uuid4()),
                        token_storage=JSONTokenStorage())
     # Mock actual call to open(). Catch the data 'written' and use it in the
@@ -20,7 +20,7 @@ def test_json_token_storage(mock_token_response, mock_revoke, monkeypatch):
     monkeypatch.setattr(os.path, 'exists', lambda x: True)
     mo = mock_open()
     with patch('builtins.open', mo):
-        cli.save_tokens(mock_token_response)
+        cli.save_tokens(mock_tokens)
         written = ''.join([c[1][0] for c in mo().write.mock_calls])
     with patch('builtins.open', mock_open(read_data=written)):
         tokens = cli.load_tokens()
@@ -44,14 +44,14 @@ def test_config_parser_read_token_storage(mock_token_response):
     assert len(tokens['resource.server.org'].values()) == 6
 
 
-def test_config_parser_write_token_storage(mock_token_response):
+def test_config_parser_write_token_storage(mock_tokens):
     cfg = ConfigParserTokenStorage(filename=CONFIGPARSER_VALID_CFG)
     mo = mock_open()
     with patch('builtins.open', mo):
-        cfg.write_tokens(mock_token_response)
+        cfg.write_tokens(mock_tokens)
         written = ''.join([c[1][0] for c in mo().write.mock_calls])
 
-    token_data = mock_token_response.by_resource_server['resource.server.org']
+    token_data = mock_tokens['resource.server.org']
     del token_data['refresh_token']
     for val in token_data.values():
         assert str(val) in written

--- a/tests/unit/test_storage_tools.py
+++ b/tests/unit/test_storage_tools.py
@@ -11,10 +11,20 @@ def test_check_expired_with_valid_tokens(mock_tokens):
     assert check_expired(mock_tokens) is None
 
 
-def test_check_expired(mock_tokens):
-    mock_tokens['resource.server.org']['expires_at_seconds'] = time.time() - 1
+def test_check_expired(mock_expired_tokens):
     with pytest.raises(TokensExpired):
-        check_expired(mock_tokens)
+        check_expired(mock_expired_tokens)
+
+
+def test_expired_contains_useful_info(mock_expired_tokens):
+    exc = None
+    try:
+        check_expired(mock_expired_tokens)
+    except TokensExpired as te:
+        exc = te
+    assert exc
+    for token in mock_expired_tokens:
+        assert token in str(exc)
 
 
 def test_check_scopes_with_valid_scopes(mock_tokens):

--- a/tests/unit/test_storage_tools.py
+++ b/tests/unit/test_storage_tools.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 from native_login.token_storage import (
     check_expired, check_scopes, flat_pack, flat_unpack


### PR DESCRIPTION
Code Changes for #8. Also supports using the authorizer `on_refresh()` hook for auto-saving newly refreshed tokens. 