### PR TITLE
Overhauled storage handling for special use-cases and security

### DIFF
--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -385,7 +385,7 @@ class NativeClient(object):
                 }, ...
             }
         """
-        return set(cls.get_scope_set(tokens)) == set(requested_scopes)
+        return set(requested_scopes).issubset(set(cls.get_scope_set(tokens)))
 
     @staticmethod
     def get_expired(tokens):

--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -13,12 +13,74 @@ from fair_research_login.refresh import RefreshHelper
 
 
 class NativeClient(object):
-    """
+    r"""
     The Native Client serves as another small layer on top of the Globus SDK
     to automatically handle token storage and provide a customizable
     Local Server. It can be used both by simple scripts to simplify the
     auth flow, or by full command line clients that may extend various pieces
     and tailor them to its own needs.
+    **Parameters**
+        ``client_id`` (*string*)
+          The id for your app. Register one at https://developers.globus.org
+        ``app_name`` (*string*)
+          The name of your app. Shows up on the named grant during consent,
+          and the local server browser page by default. It is also propogated
+          to globus_sdk.NativeAppAuthClient.
+        ``default_scopes`` (*list*)
+          A list of scopes which will serve as the default to login() if
+          login is called with no requested_scopes parameter.
+          Example:
+          ['openid', 'profile', 'email']
+        ``token_storage`` (*object*)
+          Any object capable of reading/writing/clearing tokens from/to disk.
+          The object must define these three methods: read_tokens(),
+          write_tokens(tokens), and clear_tokens(), where ``tokens`` is a list
+          of login groups (dicts), each of which contains a token group (dict)
+          keyed by resource server.
+
+          Example ``tokens``:
+          [{
+            'auth.globus.org': {
+                'scope': 'openid profile email',
+                'access_token': '<token>',
+                'refresh_token': None,
+                'token_type': 'Bearer',
+                'expires_at_seconds': 1234567,
+                'resource_server': 'auth.globus.org'
+            }
+          }]
+
+          A default token storage object is provided
+          at fair_research_login.token_storage.MultiClientTokenStorage, which
+          saves tokens in a section named by your clients ``client_id``. None
+          may be used to disable token storage.
+        ``local_server_code_handler`` (:class:`CodeHandler \
+          <fair_research_login.code_handler.CodeHandler>`)
+          A Local Code handler capable of fetching and returning the
+          authorization code generated as a browser query param in Globus Auth
+          Used during login(), but can be disabled with
+          login(no_local_server=True)
+        ``secondary_code_handler`` (:class:`CodeHandler \
+          <fair_research_login.code_handler.CodeHandler>`)
+          Handler to be used if the ``local_server_code_handler`` has been
+          disabled.
+
+    ** Methods **
+
+    *  :py:meth:`.login`
+    *  :py:meth:`.logout`
+    *  :py:meth:`.load_tokens`
+    *  :py:meth:`.get_authorizers`
+    *  :py:meth:`.revoke_token_set`
+    *  :py:meth:`.are_refreshable`
+    *  :py:meth:`.check_scopes`
+    *  :py:meth:`.get_scope_set`
+    *  :py:meth:`.refresh_tokens`
+
+    ** Example **
+
+    cli = NativeClient(client_id='my_id', app_name='my cool app')
+    cli.login(requested_scopes=['openid', 'profile', 'email'])
     """
 
     TOKEN_STORAGE_ATTRS = {'write_tokens', 'read_tokens', 'clear_tokens'}
@@ -48,18 +110,31 @@ class NativeClient(object):
         first attempts to load tokens and will simply return those if they are
         valid, and will automatically attempt to save tokens on login success
         (token_storage must be set for automatic load/save functionality).
-        :param no_local_server: Don't use the local server. This may be because
-        of permissions issues of standing up a server on the clients machine.
-        :param no_browser: Don't automatically open a browser, and instead
-        instruct the user to manually follow the URL to login. This is useful
-        on remote servers which don't have native browsers for clients to use.
-        :param requested_scopes: Globus Scopes to request on the users behalf.
-        :param refresh_tokens: Use refresh tokens to extend login time
-        :param prefill_named_grant: Named Grant to use on Consent Page
-        :param additional_params: Additional Params to supply, such as for
-        using Globus Sessions
-        :param force: Force a login flow, even if loaded tokens are valid.
-        :return:
+        See ``load_tokens`` for how it handles requested_scopes.
+        **Parameters**
+        ``no_local_server`` (*bool*)
+          Disable spinning up a local server to automatically copy-paste the
+          auth code. THIS IS REQUIRED if you are on a remote server, as this
+          package isn't able to determine the domain of a remote service. When
+          used locally with no_local_server=False, the domain is localhost with
+          a randomly chosen open port number.
+        ``no_browser`` (*string*)
+          Do not automatically open the browser for the Globus Auth URL.
+          Display the URL instead and let the user navigate to that location.
+        ``requested_scopes`` (*list*)
+          A list of scopes to request of Globus Auth during login.
+          Example:
+          ['openid', 'profile', 'email']
+        ``refresh_tokens`` (*bool*)
+          Ask for Globus Refresh Tokens to extend login time.
+        ``prefill_named_grant`` (*bool*)
+          Use a custom named grant on the consent page
+        ``additional_params`` (*dict*)
+          Additional Params used in constructing the authorize URL for Globus
+          Auth. Used for requesting additional features such as for using
+          Globus Sessions.
+        ``force`` (*bool*)
+          Force a login flow, even if loaded tokens are valid.
         """
         if force is False:
             try:
@@ -97,17 +172,23 @@ class NativeClient(object):
         return token_response.by_resource_server
 
     def verify_token_storage(self, obj):
+        """
+        Internal. Verify object passed for token_storage is valid.
+        """
         for attr in self.TOKEN_STORAGE_ATTRS:
             if getattr(obj, attr, None) is None:
                 raise AttributeError('token_storage requires object "{}" to '
                                      'have the {} attribute'.format(obj, attr))
 
     def save_tokens(self, tokens):
-        """
+        r"""
         Save tokens if token_storage is set. Typically this is called
         automatically in a successful login().
-        :param tokens: globus_sdk.auth.token_response.OAuthTokenResponse.
-        :return: None
+        **Parameters**
+        ``tokens`` (**list**)
+          A list of all user logins, each containing a dict defined by
+            globus_sdk.auth.token_response.OAuthTokenResponse\
+            .by_resource_server.
         """
         if self.token_storage is not None:
             return self.token_storage.write_tokens(tokens)
@@ -119,8 +200,8 @@ class NativeClient(object):
 
     def _load_raw_tokens(self):
         """
-        Loads tokens without checking them
-        :return: tokens by resource server, or an exception if that fails
+        Loads tokens without checking whether they have expired. Sorts them by
+        expiration time.
         """
         if self.token_storage is not None:
             login_group = self.token_storage.read_tokens()
@@ -133,10 +214,15 @@ class NativeClient(object):
 
     def load_tokens(self, requested_scopes=None):
         """
-        Load tokens from the set token_storage object if one exists.
-        :param requested_scopes: Check that the loaded scopes match these
-        requested scopes. Raises ScopesMismatch if there is a discrepancy.
-        :return: Loaded tokens, or a LoadError if loading fails.
+        Load tokens from the set token_storage object if one exists. If
+        requested_scopes is None, it returns the most recent login tokens.
+        Otherwise, it searches for unexpired tokens which match the
+        requested scopes. Raises ScopesMismatch if no scopes match, and
+        TokensExpired if there was a match but they expired.
+        **Parameters**
+        ``requested_scopes`` (*list*)
+          A list of scopes. Example:
+          ['openid', 'profile', 'email']
         """
         if requested_scopes is not None and isinstance(requested_scopes, str):
             requested_scopes = requested_scopes.split(' ')
@@ -172,6 +258,9 @@ class NativeClient(object):
                                  .format(requested_scopes))
 
     def refresh_tokens(self, tokens):
+        """
+        Explicitly refresh a token. Called automatically by load_tokens().
+        """
         if not self.are_refreshable(tokens):
             raise TokensExpired('No Refresh Token, cannot refresh tokens: ',
                                 resource_servers=tokens.keys())
@@ -189,6 +278,18 @@ class NativeClient(object):
         return tokens
 
     def get_authorizers(self, requested_scopes=None):
+        """
+        Load tokens and create TokenAuthorizers for them. Automatically
+        creates a globus_sdk.RefreshTokenAuthorizer if possible, otherwise an
+        globus_sdk.AccessTokenAuthorizer. Authorizers are organized by resource
+        server. Raises a fair_research_login.exc.LoadError if Token Storage
+        is disabled, no tokens were saved, or if the tokens expired or the
+        requested scopes don't match. Calls load_tokens() internally.
+        **Parameters**
+        ``requested_scopes`` (*list*)
+          A list of scopes. Example:
+          ['openid', 'profile', 'email']
+        """
         tokens = self.load_tokens(requested_scopes=requested_scopes)
         explicit_scopes = requested_scopes or self.get_scope_set(tokens)
         authorizers = {}
@@ -209,32 +310,75 @@ class NativeClient(object):
 
     def logout(self):
         """
-        Revoke saved tokens and clear them from storage
+        Revoke saved tokens and clear them from storage. Raises
+        fair_research_login.exc.TokenStorageDisabled if no token storage is
+        set, otherwise attempts to revoke tokens then returns None.
         """
         for tset in self._load_raw_tokens():
             self.revoke_token_set(tset)
         self.token_storage.clear_tokens()
 
     def revoke_token_set(self, tokens):
+        """
+        Revoke Tokens for a given token group.
+        **parameters**
+          ``tokens`` (*dict*)
+          An object matching
+          globus_sdk.auth.token_response.OAuthTokenResponse.by_resource_server
+        """
         for rs, tok_set in tokens.items():
             self.client.oauth2_revoke_token(tok_set.get('access_token'))
             self.client.oauth2_revoke_token(tok_set.get('refresh_token'))
 
     @staticmethod
     def get_scope_set(token_group):
+        """
+        Returns a list of scopes given a token_group organized by:
+        globus_sdk.auth.token_response.OAuthTokenResponse.by_resource_server
+        """
         scopes = [tset['scope'].split() for tset in token_group.values()]
         flat_list = [item for sublist in scopes for item in sublist]
         return flat_list
 
     @classmethod
     def check_scopes(cls, tokens, requested_scopes):
+        """
+        Returns true if scopes match the tokens passed in, false otherwise.
+        **Parameters**
+          ``tokens`` (**dict**)
+          A token grouping, organized by:
+          globus_sdk.auth.token_response.OAuthTokenResponse.by_resource_server
+          Example:
+            {
+                'auth.globus.org': {
+                    'scope': 'openid profile email',
+                    'access_token': '<token>',
+                    'refresh_token': None,
+                    'token_type': 'Bearer',
+                    'expires_at_seconds': 1234567,
+                    'resource_server': 'auth.globus.org'
+                }, ...
+            }
+        """
         return set(cls.get_scope_set(tokens)) == set(requested_scopes)
 
     @staticmethod
     def get_expired(tokens):
+        """
+        Returns a Token Group organized by:
+        globus_sdk.auth.token_response.OAuthTokenResponse.by_resource_server
+        For all tokens in that group that are expired. Ignores whether there
+        is a refresh token attached to that token.
+        """
         return {rs: tset for rs, tset in tokens.items()
                 if time.time() >= tset['expires_at_seconds']}
 
     @staticmethod
     def are_refreshable(tokens):
+        """
+        Returns True if all tokens in the group organized by:
+        globus_sdk.auth.token_response.OAuthTokenResponse.by_resource_server
+        have refresh tokens. This should always return True with tokens stored
+        from a login(refresh_tokens=True).
+        """
         return all([bool(ts['refresh_token']) for ts in tokens.values()])

--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -6,7 +6,11 @@ from fair_research_login.local_server import LocalServerCodeHandler
 from fair_research_login.token_storage import (
     MultiClientTokenStorage, check_expired, check_scopes
 )
-from fair_research_login.exc import LoadError, TokensExpired
+from fair_research_login.exc import (
+    LoadError, TokensExpired, TokenStorageDisabled, NoSavedTokens,
+    ScopesMismatch
+)
+from fair_research_login.refresh import RefreshHelper
 
 
 class NativeClient(object):
@@ -82,7 +86,13 @@ class NativeClient(object):
                                                   no_browser=no_browser)
         token_response = self.client.oauth2_exchange_code_for_tokens(auth_code)
         try:
-            self.save_tokens(token_response.by_resource_server)
+            tokens = []
+            try:
+                tokens = self._load_raw_tokens()
+            except LoadError:
+                pass
+            tokens.append(token_response.by_resource_server)
+            self.save_tokens(tokens)
         except LoadError:
             pass
         return token_response.by_resource_server
@@ -102,7 +112,11 @@ class NativeClient(object):
         """
         if self.token_storage is not None:
             return self.token_storage.write_tokens(tokens)
-        raise LoadError('No token_storage set on client.')
+        raise TokenStorageDisabled('No token_storage set on client.')
+
+    def _get_newest_token(self, token_group):
+        exps = [item['expires_at_seconds'] for item in token_group.values()]
+        return max(exps)
 
     def _load_raw_tokens(self):
         """
@@ -110,8 +124,13 @@ class NativeClient(object):
         :return: tokens by resource server, or an exception if that fails
         """
         if self.token_storage is not None:
-            return self.token_storage.read_tokens()
-        raise LoadError('No token_storage set on client.')
+            login_group = self.token_storage.read_tokens()
+            login_group.sort(
+                key=lambda tgroup: self._get_newest_token(tgroup),
+                reverse=True
+            )
+            return login_group
+        raise TokenStorageDisabled('No token_storage set on client.')
 
     def load_tokens(self, requested_scopes=None):
         """
@@ -120,31 +139,41 @@ class NativeClient(object):
         requested scopes. Raises ScopesMismatch if there is a discrepancy.
         :return: Loaded tokens, or a LoadError if loading fails.
         """
-        tokens = self._load_raw_tokens()
-
         if requested_scopes is not None and isinstance(requested_scopes, str):
             requested_scopes = requested_scopes.split(' ')
 
-        if not tokens:
-            raise LoadError('No Tokens loaded')
+        login_list = self._load_raw_tokens()
 
-        if requested_scopes not in [None, ()]:
-            check_scopes(tokens, requested_scopes)
-        try:
-            check_expired(tokens)
-        except TokensExpired as te:
-            expired = {rs: tokens[rs] for rs in te.resource_servers}
-            if not self._refreshable(expired):
-                raise
-            tokens.update(self.refresh_tokens(expired))
-            self.save_tokens(tokens)
-        return tokens
+        if not login_list:
+            raise NoSavedTokens('No tokens are available.')
 
-    def _refreshable(self, tokens):
-        return all([bool(ts['refresh_token']) for ts in tokens.values()])
+        # Flag to check if there was a scope match when checking tokens. If
+        # there was, but they expired, we prefer to throw an expired exception.
+        scope_match = False
+        for tok_candidate in login_list:
+            if requested_scopes not in [None, ()]:
+                if not check_scopes(tok_candidate, requested_scopes):
+                    continue
+            scope_match = True
+            try:
+                check_expired(tok_candidate)
+            except TokensExpired as te:
+                expired = {rs: tok_candidate[rs] for rs in te.resource_servers}
+                if not self.are_refreshable(expired):
+                    continue
+                tok_candidate.update(self.refresh_tokens(expired))
+                self.save_tokens(login_list)
+            return tok_candidate
+
+        if scope_match:
+            raise TokensExpired('A previous login matched {} but the tokens '
+                                'have expired.'.format(requested_scopes))
+        else:
+            raise ScopesMismatch('No saved tokens match the scopes: {}'
+                                 .format(requested_scopes))
 
     def refresh_tokens(self, tokens):
-        if not self._refreshable(tokens):
+        if not self.are_refreshable(tokens):
             raise TokensExpired('No Refresh Token, cannot refresh tokens: ',
                                 resource_servers=tokens.keys())
 
@@ -162,6 +191,7 @@ class NativeClient(object):
 
     def get_authorizers(self, requested_scopes=None):
         tokens = self.load_tokens(requested_scopes=requested_scopes)
+        explicit_scopes = requested_scopes or self.get_scope_set(tokens)
         authorizers = {}
         for resource_server, token_dict in tokens.items():
             if token_dict.get('refresh_token') is not None:
@@ -170,7 +200,7 @@ class NativeClient(object):
                     self.client,
                     access_token=token_dict['access_token'],
                     expires_at=token_dict['expires_at_seconds'],
-                    on_refresh=self.on_refresh,
+                    on_refresh=RefreshHelper(self, explicit_scopes),
                 )
             else:
                 authorizers[resource_server] = AccessTokenAuthorizer(
@@ -178,19 +208,29 @@ class NativeClient(object):
                 )
         return authorizers
 
-    def on_refresh(self, token_response):
-        loaded_tokens = self._load_raw_tokens()
-        loaded_tokens.update(token_response.by_resource_server)
-        self.save_tokens(loaded_tokens)
-
     def logout(self):
         """
         Revoke saved tokens and clear them from storage
         """
-        self.revoke_token_set(self._load_raw_tokens())
+        for tset in self._load_raw_tokens():
+            self.revoke_token_set(tset)
         self.token_storage.clear_tokens()
 
     def revoke_token_set(self, tokens):
         for rs, tok_set in tokens.items():
             self.client.oauth2_revoke_token(tok_set.get('access_token'))
             self.client.oauth2_revoke_token(tok_set.get('refresh_token'))
+
+    @staticmethod
+    def get_scope_set(token_group):
+        scopes = [tset['scope'].split() for tset in token_group.values()]
+        flat_list = [item for sublist in scopes for item in sublist]
+        return flat_list
+
+    @classmethod
+    def check_scopes(cls, tokens, requested_scopes):
+        return set(cls.get_scope_set(tokens)) == set(requested_scopes)
+
+    @staticmethod
+    def are_refreshable(tokens):
+        return all([bool(ts['refresh_token']) for ts in tokens.values()])

--- a/fair_research_login/exc.py
+++ b/fair_research_login/exc.py
@@ -12,6 +12,15 @@ class LoadError(LoginException):
     pass
 
 
+class TokenStorageDisabled(LoadError):
+    pass
+
+
+class NoSavedTokens(LoadError):
+    """There were no saved tokens to load"""
+    pass
+
+
 class ScopesMismatch(LoadError):
     """
     Requested scopes do not match loaded scopes
@@ -26,9 +35,9 @@ class TokensExpired(LoadError):
     def __init__(self, *args, **kwargs):
         super(TokensExpired, self).__init__(*args)
         self.resource_servers = kwargs.get('resource_servers', ())
+        self.scopes = kwargs.get('scopes', ())
 
     def __str__(self):
         return '{} {}'.format(
-            super(TokensExpired, self).__str__(),
-            ', '.join(self.resource_servers)
+            super(TokensExpired, self).__str__(), ', '.join(self.scopes)
         )

--- a/fair_research_login/refresh.py
+++ b/fair_research_login/refresh.py
@@ -1,0 +1,15 @@
+
+
+class RefreshHelper(object):
+
+    def __init__(self, native_client_instance, scope_set):
+        self.nc_instance = native_client_instance
+        self.scope_set = scope_set
+
+    def __call__(self, token_response):
+        login_groups = self.nc_instance._load_raw_tokens()
+        for login_group in login_groups:
+            if self.nc_instance.check_scopes(login_group, self.scope_set):
+                login_group.update(token_response.by_resource_server)
+                break
+        self.nc_instance.save_tokens(login_groups)

--- a/fair_research_login/token_storage/__init__.py
+++ b/fair_research_login/token_storage/__init__.py
@@ -5,12 +5,12 @@ from fair_research_login.token_storage.configparser_token_storage import (
     ConfigParserTokenStorage, MultiClientTokenStorage
 )
 from fair_research_login.token_storage.storage_tools import (
-    flat_pack, flat_unpack, check_expired, check_scopes,
+    flat_pack, flat_unpack
 )
 
 __all__ = [
     'JSONTokenStorage', 'ConfigParserTokenStorage',
     'MultiClientTokenStorage',
 
-    'flat_pack', 'flat_unpack', 'check_expired', 'check_scopes'
+    'flat_pack', 'flat_unpack'
 ]

--- a/fair_research_login/token_storage/storage_tools.py
+++ b/fair_research_login/token_storage/storage_tools.py
@@ -1,25 +1,4 @@
-import time
-
-from fair_research_login.exc import TokensExpired, ScopesMismatch, LoadError
-
-
-def check_expired(tokens):
-    expired = [
-        rs for rs, tset in tokens.items()
-        if time.time() >= tset['expires_at_seconds']
-    ]
-    if expired:
-        raise TokensExpired(resource_servers=expired)
-
-
-def check_scopes(tokens, requested_scopes):
-    scopes = [tset['scope'].split() for tset in tokens.values()]
-    flat_list = [item for sublist in scopes for item in sublist]
-    if set(flat_list) != set(requested_scopes):
-        raise ScopesMismatch('Requested Scopes do not match loaded'
-                             ' Scopes for Globus Auth. \nCurrent: {}\n'
-                             'Requested: {}'.format(set(flat_list),
-                                                    set(requested_scopes)))
+from fair_research_login.exc import LoadError
 
 
 def default_name_key(group_key, key, login):

--- a/tests/integration/test_client_refresh.py
+++ b/tests/integration/test_client_refresh.py
@@ -1,23 +1,29 @@
 
 """
-The most basic usage automatically saves and loads tokens, and provides
-a local server for logging in users.
+Tests real usage of the tool, for some things that can't be tested via mocking.
+
+Enable by setting:
+export SKIP_INTEGRATION_TESTS=False
 """
+import os
 import pytest
 import globus_sdk
 
+SKIP_INTEG = bool(os.getenv('SKIP_INTEGRATION_TESTS') != 'False')
 
-@pytest.mark.skip(reason='Integration test')
+
+@pytest.mark.skipif(SKIP_INTEG, reason='Integration test')
 def test_refresh(live_client):
+    live_client.logout()
     tokens = live_client.login(refresh_tokens=True)
     for tset in tokens.values():
         tset['expires_at_seconds'] = 0
-    live_client.save_tokens(tokens)
+    live_client.save_tokens([tokens])
     for rs, new_tokens in live_client.load_tokens().items():
         assert tokens[rs]['access_token'] != new_tokens['access_token']
 
 
-@pytest.mark.skip(reason='Integration test')
+@pytest.mark.skipif(SKIP_INTEG, reason='Integration test')
 def test_authorizer_refresh_hook(live_client):
     tokens = live_client.login(refresh_tokens=True)
     old_access_token = tokens['auth.globus.org']['access_token']
@@ -33,7 +39,7 @@ def test_authorizer_refresh_hook(live_client):
     assert saved_token != old_access_token
 
 
-@pytest.mark.skip(reason='Integration test')
+@pytest.mark.skip(SKIP_INTEG, reason='Integration test')
 @pytest.mark.trylast
 def test_refresh_no_longer_works_after_logout(live_client):
     tokens = live_client.login(refresh_tokens=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,22 +25,27 @@ def mock_tokens():
 
 
 @pytest.fixture
-def mock_tokens_underscores():
-    return deepcopy(MOCK_TOKEN_SET_UNDERSCORES)
+def login_token_group_underscores():
+    return [deepcopy(MOCK_TOKEN_SET_UNDERSCORES)]
 
 
 @pytest.fixture
-def mock_expired_tokens(mock_tokens):
+def login_token_group(mock_tokens):
+    return [mock_tokens]
+
+
+@pytest.fixture
+def expired_login_group(mock_tokens):
     for tset in mock_tokens.values():
         tset['expires_at_seconds'] = 0
-    return mock_tokens
+    return [mock_tokens]
 
 
 @pytest.fixture
-def expired_tokens_with_refresh(mock_expired_tokens):
-    for tset in mock_expired_tokens.values():
+def expired_login_with_refresh(expired_login_group):
+    for tset in expired_login_group[0].values():
         tset['refresh_token'] = '<Mock Refresh Token>'
-    return mock_expired_tokens
+    return expired_login_group
 
 
 @pytest.fixture

--- a/tests/unit/data/configparser_valid.cfg
+++ b/tests/unit/data/configparser_valid.cfg
@@ -1,8 +1,19 @@
 [tokens]
-resource_server_org__scope = custom_scope
-resource_server_org__access_token = <token>
-resource_server_org__refresh_token = 
-resource_server_org__token_type = Bearer
-resource_server_org__expires_at_seconds = 1549639833
-resource_server_org__resource_server = resource.server.org
-
+login_0__auth_globus_org__access_token = <token>
+login_0__auth_globus_org__expires_at_seconds = 1558804646
+login_0__auth_globus_org__refresh_token = 
+login_0__auth_globus_org__resource_server = auth.globus.org
+login_0__auth_globus_org__scope = openid profile email
+login_0__auth_globus_org__token_type = Bearer
+login_0__resource_server_org__access_token = <token>
+login_0__resource_server_org__expires_at_seconds = 1558804646
+login_0__resource_server_org__refresh_token = 
+login_0__resource_server_org__resource_server = resource.server.org
+login_0__resource_server_org__scope = custom_scope
+login_0__resource_server_org__token_type = Bearer
+login_0__transfer_api_globus_org__access_token = <token>
+login_0__transfer_api_globus_org__expires_at_seconds = 1558804646
+login_0__transfer_api_globus_org__refresh_token = 
+login_0__transfer_api_globus_org__resource_server = transfer.api.globus.org
+login_0__transfer_api_globus_org__scope = urn:globus:auth:scope:transfer.api.globus.org:all
+login_0__transfer_api_globus_org__token_type = Bearer

--- a/tests/unit/data/configparser_valid_legacy.cfg
+++ b/tests/unit/data/configparser_valid_legacy.cfg
@@ -1,0 +1,8 @@
+[tokens]
+resource_server_org__scope = custom_scope
+resource_server_org__access_token = <token>
+resource_server_org__refresh_token = 
+resource_server_org__token_type = Bearer
+resource_server_org__expires_at_seconds = 1549639833
+resource_server_org__resource_server = resource.server.org
+

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -50,7 +50,7 @@ MOCK_TOKEN_SET_UNDERSCORES = {
 class MemoryStorage(object):
     def __init__(self):
         super(MemoryStorage, self).__init__()
-        self.tokens = {}
+        self.tokens = []
 
     def write_tokens(self, tokens):
         self.tokens = tokens
@@ -59,4 +59,4 @@ class MemoryStorage(object):
         return self.tokens
 
     def clear_tokens(self):
-        self.tokens = {}
+        self.tokens = []

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -4,6 +4,9 @@ import os
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 CONFIGPARSER_VALID_CFG = os.path.join(DATA_PATH, 'configparser_valid.cfg')
+CONFIGPARSER_VALID_LEGACY_CFG = os.path.join(
+    DATA_PATH, 'configparser_valid_legacy.cfg'
+)
 
 DEFAULT_EXPIRE = int(time.time()) + 60 * 60 * 48
 
@@ -37,7 +40,7 @@ MOCK_TOKEN_SET = {
 
 MOCK_TOKEN_SET_UNDERSCORES = {
     'resource_server_with_underscores': {
-        'scope': 'all',
+        'scope': 'rs_w_underscores_scope',
         'access_token': '<token>',
         'refresh_token': None,
         'token_type': 'Bearer',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -227,27 +227,21 @@ def test_client_when_cannot_refresh(expired_login_group, mem_storage,
         cli.load_tokens()
 
 
-# def test_check_expired_with_valid_tokens(mock_tokens):
-#     assert check_expired(mock_tokens) is None
-#
-#
-# def test_check_expired(mock_expired_tokens):
-#     with pytest.raises(TokensExpired):
-#         check_expired(mock_expired_tokens)
-#
-#
-# def test_expired_contains_useful_info(mock_expired_tokens):
-#     exc = None
-#     try:
-#         check_expired(mock_expired_tokens)
-#     except TokensExpired as te:
-#         exc = te
-#     assert exc
-#     for token in mock_expired_tokens:
-#         assert token in str(exc)
-#
-#
-# def test_check_scopes_with_valid_scopes(mock_tokens):
-#     scopes = ['custom_scope', 'profile', 'openid', 'email',
-#               'urn:globus:auth:scope:transfer.api.globus.org:all']
-#     assert check_scopes(mock_tokens, scopes) is None
+def test_get_expired_with_valid_tokens(mock_tokens):
+    assert not NativeClient.get_expired(mock_tokens)
+
+
+def test_get_expired(expired_login_group):
+    expired = NativeClient.get_expired(expired_login_group[0])
+    assert expired == expired_login_group[0]
+
+
+def test_get_scope_set(mock_tokens):
+    scopes = {'custom_scope', 'profile', 'openid', 'email',
+              'urn:globus:auth:scope:transfer.api.globus.org:all'}
+    assert set(NativeClient.get_scope_set(mock_tokens)) == scopes
+
+
+def test_check_scopes_with_valid_scopes(expired_login_group):
+    scopes = NativeClient.get_scope_set(expired_login_group[0])
+    assert NativeClient.check_scopes(expired_login_group[0], scopes) is True

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -269,7 +269,7 @@ def test_check_scopes_with_valid_scopes(mock_tokens):
 
 def test_check_scopes_with_differing_scopes(mock_tokens):
     ck = NativeClient.check_scopes(mock_tokens, ['scope_was_never_requested'])
-    assert ck == False
+    assert ck is False
 
 
 def test_subset_does_not_raise_errors(mock_tokens):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -8,7 +8,9 @@ from fair_research_login.token_storage.configparser_token_storage import (
 )
 from fair_research_login.local_server import LocalServerCodeHandler
 from fair_research_login.code_handler import InputCodeHandler
-from fair_research_login.exc import LoadError, ScopesMismatch, TokensExpired
+from fair_research_login.exc import (
+    LoadError, ScopesMismatch, TokensExpired, NoSavedTokens
+)
 from fair_research_login.version import __version__
 
 
@@ -107,6 +109,13 @@ def test_login_with_no_storage(mock_input, mock_webbrowser,
     assert tokens == mock_token_response.by_resource_server
 
 
+def test_load_with_no_saved_tokens(mem_storage):
+    mem_storage.tokens = []
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    with pytest.raises(NoSavedTokens):
+        cli.load_tokens()
+
+
 def test_load_raises_scopes_mismatch(mem_storage, login_token_group):
     cli = NativeClient(client_id=str(uuid4()),
                        token_storage=mem_storage)
@@ -140,6 +149,24 @@ def test_client_load_errors_silenced_on_login(
                        token_storage=None)
     tokens = cli.login()
     assert tokens == mock_token_response.by_resource_server
+
+
+def test_load_resolves_scopes_on_multi_login(
+        mem_storage, mock_tokens,
+        login_token_group_underscores):
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    mem_storage.tokens = [
+        {'auth.globus.org': mock_tokens['auth.globus.org']},
+        mock_tokens,
+        login_token_group_underscores[0],
+    ]
+    # None of these should throw errors
+    cli.load_tokens(requested_scopes=['rs_w_underscores_scope'])
+    cli.load_tokens(requested_scopes=['openid', 'email', 'profile'])
+    cli.load_tokens(requested_scopes=[
+        'custom_scope', 'urn:globus:auth:scope:transfer.api.globus.org:all',
+        'openid', 'email', 'profile'
+    ])
 
 
 def test_client_token_refresh_without_tokens_raises(mock_tokens):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -133,10 +133,10 @@ def test_load_raises_scopes_mismatch(mem_storage, login_token_group):
 
 
 def test_load_accepts_string_or_iterable_requested_scopes(mem_storage,
-                                                          mock_tokens):
+                                                          login_token_group):
     cli = NativeClient(client_id=str(uuid4()),
                        token_storage=mem_storage)
-    mem_storage.tokens = mock_tokens
+    mem_storage.tokens = login_token_group
     scopes = ('openid profile email custom_scope '
               'urn:globus:auth:scope:transfer.api.globus.org:all')
     tokens = cli.load_tokens(scopes)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -262,6 +262,15 @@ def test_get_scope_set(mock_tokens):
     assert set(NativeClient.get_scope_set(mock_tokens)) == scopes
 
 
-def test_check_scopes_with_valid_scopes(expired_login_group):
-    scopes = NativeClient.get_scope_set(expired_login_group[0])
-    assert NativeClient.check_scopes(expired_login_group[0], scopes) is True
+def test_check_scopes_with_valid_scopes(mock_tokens):
+    scopes = NativeClient.get_scope_set(mock_tokens)
+    assert NativeClient.check_scopes(mock_tokens, scopes) is True
+
+
+def test_check_scopes_with_differing_scopes(mock_tokens):
+    ck = NativeClient.check_scopes(mock_tokens, ['scope_was_never_requested'])
+    assert ck == False
+
+
+def test_subset_does_not_raise_errors(mock_tokens):
+    assert NativeClient.check_scopes(mock_tokens, ['custom_scope']) is True

--- a/tests/unit/test_exc.py
+++ b/tests/unit/test_exc.py
@@ -1,0 +1,7 @@
+from fair_research_login.exc import TokensExpired
+
+
+def test_tokens_expired_str_contains_scopes():
+    scopes = ['foo', 'bar', 'baz']
+    te = TokensExpired('oh noes!', scopes=scopes)
+    assert all([s in str(te) for s in scopes])

--- a/tests/unit/test_storage_classes.py
+++ b/tests/unit/test_storage_classes.py
@@ -11,7 +11,8 @@ except ImportError:
 
 from fair_research_login import (ConfigParserTokenStorage, JSONTokenStorage,
                                  NativeClient)
-from .mocks import MOCK_TOKEN_SET, CONFIGPARSER_VALID_CFG
+from .mocks import (MOCK_TOKEN_SET, CONFIGPARSER_VALID_CFG,
+                    CONFIGPARSER_VALID_LEGACY_CFG)
 
 if sys.version_info.major == 3:
     BUILTIN_OPEN = 'builtins.open'
@@ -46,6 +47,16 @@ def test_json_token_storage_non_existant_filename():
 
 def test_config_parser_read_token_storage(mock_token_response):
     cfg = ConfigParserTokenStorage(filename=CONFIGPARSER_VALID_CFG)
+    login_groups = cfg.read_tokens()
+    assert len(login_groups) == 1
+    tokens = login_groups[0]
+    assert isinstance(tokens, dict)
+    assert tokens.get('resource.server.org')
+    assert len(tokens['resource.server.org'].values()) == 6
+
+
+def test_config_parser_legacy_storage(mock_token_response):
+    cfg = ConfigParserTokenStorage(filename=CONFIGPARSER_VALID_LEGACY_CFG)
     login_groups = cfg.read_tokens()
     assert len(login_groups) == 1
     tokens = login_groups[0]

--- a/tests/unit/test_storage_tools.py
+++ b/tests/unit/test_storage_tools.py
@@ -1,35 +1,9 @@
 import pytest
 
 from fair_research_login.token_storage import (
-    check_expired, check_scopes, flat_pack, flat_unpack
+    check_scopes, flat_pack, flat_unpack
 )
-from fair_research_login.exc import TokensExpired, ScopesMismatch
-
-
-def test_check_expired_with_valid_tokens(mock_tokens):
-    assert check_expired(mock_tokens) is None
-
-
-def test_check_expired(mock_expired_tokens):
-    with pytest.raises(TokensExpired):
-        check_expired(mock_expired_tokens)
-
-
-def test_expired_contains_useful_info(mock_expired_tokens):
-    exc = None
-    try:
-        check_expired(mock_expired_tokens)
-    except TokensExpired as te:
-        exc = te
-    assert exc
-    for token in mock_expired_tokens:
-        assert token in str(exc)
-
-
-def test_check_scopes_with_valid_scopes(mock_tokens):
-    scopes = ['custom_scope', 'profile', 'openid', 'email',
-              'urn:globus:auth:scope:transfer.api.globus.org:all']
-    assert check_scopes(mock_tokens, scopes) is None
+from fair_research_login.exc import ScopesMismatch
 
 
 def test_check_scopes_with_differing_scopes(mock_tokens):
@@ -37,15 +11,15 @@ def test_check_scopes_with_differing_scopes(mock_tokens):
         check_scopes(mock_tokens, ['custom_scope'])
 
 
-def test_flat_pack_unpack(mock_tokens):
-    exercised_tokens = flat_unpack(flat_pack(mock_tokens))
-    assert exercised_tokens == mock_tokens
+def test_flat_pack_unpack(login_token_group):
+    exercised_tokens = flat_unpack(flat_pack(login_token_group))
+    assert exercised_tokens == login_token_group
 
 
-def test_flat_unpack_rs_with_underscores(mock_tokens_underscores):
-    exercised_tokens = flat_unpack(flat_pack(mock_tokens_underscores))
-    assert exercised_tokens == mock_tokens_underscores
+def test_flat_unpack_rs_with_underscores(login_token_group_underscores):
+    exercised_tokens = flat_unpack(flat_pack(login_token_group_underscores))
+    assert exercised_tokens == login_token_group_underscores
 
 
 def test_flat_unpack_with_empty_value():
-    assert flat_unpack({}) == {}
+    assert flat_unpack([]) == []

--- a/tests/unit/test_storage_tools.py
+++ b/tests/unit/test_storage_tools.py
@@ -1,14 +1,8 @@
 import pytest
-
+from fair_research_login.exc import LoadError
 from fair_research_login.token_storage import (
-    check_scopes, flat_pack, flat_unpack
+    flat_pack, flat_unpack
 )
-from fair_research_login.exc import ScopesMismatch
-
-
-def test_check_scopes_with_differing_scopes(mock_tokens):
-    with pytest.raises(ScopesMismatch):
-        check_scopes(mock_tokens, ['custom_scope'])
 
 
 def test_flat_pack_unpack(login_token_group):
@@ -23,3 +17,10 @@ def test_flat_unpack_rs_with_underscores(login_token_group_underscores):
 
 def test_flat_unpack_with_empty_value():
     assert flat_unpack([]) == []
+
+
+def test_flat_pack_invalid_key_names(login_token_group):
+    packed = flat_pack(login_token_group)
+    packed['foo__bar__baz__bilium'] = 'value'
+    with pytest.raises(LoadError):
+        flat_unpack(packed)


### PR DESCRIPTION
Changes for #24, and also solves #27. These changes still need tests, but this should handle the case in automate which logs in multiple times with different scopes. For example:

    client.login(requested_scopes=['openid'])
    client.login(requested_scopes=['urn:globus:auth:scope:transfer.api.globus.org:all']
    client.load_tokens(requested_scopes=['openid'])

This should go with #22 to fetch tokens by scope instead of resource server, but I need to take another look. 


* Now captures all user logins so old token stores are not overwritten.
	* This prevents tokens "leaking", by being lost on overwrite.
* All tokens are now revoked on user logout.
* save_tokens() now takes a list of token groups as a parameter, instead
	of a single token group (Breaking Change!)
* load_tokens() now returns the most recent login that matches its scopes
	* Or the most recent if no requested scopes are given
* load_authorizers(), when refreshing, will save to the most recent scope
set that matches its requested scopes
* flat_pack/flat_unpack now handles lists of logins
	* flat_unpack() is backwards compatible, and will load old tokens
		not categorized by login

This includes breaking changes! Full logins are now captured, which
means storage now handles a list of token dicts instead of a simple
by-resource-server token dict. Custom user storage may be affected!