### PR TITLE
Fixed bug if refresh tokens cannot be refreshed

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from fair_research_login import NativeClient, ConfigParserTokenStorage
 
 
@@ -9,3 +10,14 @@ def live_client():
                           token_storage=storage,
                           default_scopes=['openid'])
     return client
+
+
+@pytest.fixture
+def live_client_destructive():
+    storage = ConfigParserTokenStorage(filename='integ_testing_destruct.cfg')
+    client = NativeClient(client_id='7414f0b4-7d05-4bb6-bb00-076fa3f17cf5',
+                          token_storage=storage,
+                          default_scopes=['openid'])
+    yield client
+    client.logout()
+    os.unlink('integ_testing_destruct.cfg')

--- a/tests/integration/test_client_refresh.py
+++ b/tests/integration/test_client_refresh.py
@@ -3,11 +3,16 @@
 The most basic usage automatically saves and loads tokens, and provides
 a local server for logging in users.
 """
+import os
 import pytest
 import globus_sdk
+import fair_research_login
+
+# Set integration tests by running `export RUN_INTEGRATION_TESTS=True`
+RUN_INTEGRATION_TESTS = os.getenv('RUN_INTEGRATION_TESTS') == 'True'
 
 
-@pytest.mark.skip(reason='Integration test')
+@pytest.mark.skipif(not RUN_INTEGRATION_TESTS, reason='Integration test')
 def test_refresh(live_client):
     tokens = live_client.login(refresh_tokens=True)
     for tset in tokens.values():
@@ -17,7 +22,7 @@ def test_refresh(live_client):
         assert tokens[rs]['access_token'] != new_tokens['access_token']
 
 
-@pytest.mark.skip(reason='Integration test')
+@pytest.mark.skipif(not RUN_INTEGRATION_TESTS, reason='Integration test')
 def test_authorizer_refresh_hook(live_client):
     tokens = live_client.login(refresh_tokens=True)
     old_access_token = tokens['auth.globus.org']['access_token']
@@ -33,14 +38,39 @@ def test_authorizer_refresh_hook(live_client):
     assert saved_token != old_access_token
 
 
-@pytest.mark.skip(reason='Integration test')
-@pytest.mark.trylast
-def test_refresh_no_longer_works_after_logout(live_client):
-    tokens = live_client.login(refresh_tokens=True)
-    live_client.logout()
-    live_client.save_tokens(tokens)
+@pytest.mark.skipif(not RUN_INTEGRATION_TESTS, reason='Integration test')
+def test_refresh_no_longer_works_after_logout(live_client_destructive):
+    tokens = live_client_destructive.login(refresh_tokens=True)
+    live_client_destructive.logout()
+    live_client_destructive.save_tokens(tokens)
 
-    auth = live_client.get_authorizers()['auth.globus.org']
+    auth = live_client_destructive.get_authorizers()['auth.globus.org']
     auth.expires_at = 0
     with pytest.raises(globus_sdk.exc.AuthAPIError):
         auth.check_expiration_time()
+
+
+@pytest.mark.skipif(not RUN_INTEGRATION_TESTS, reason='Integration test')
+def test_load_live_token_when_another_inactive(live_client_destructive):
+    tokens = live_client_destructive.login()
+    tokens['auth.globus.org']['expires_at_seconds'] = 0
+    live_client_destructive.save_tokens(tokens)
+    new_scope = ['urn:globus:auth:scope:transfer.api.globus.org:all']
+    live_client_destructive.login(requested_scopes=new_scope)
+
+    assert len(live_client_destructive.load_tokens().keys()) == 1
+    tk = live_client_destructive.load_tokens(requested_scopes=new_scope).keys()
+    assert len(tk) == 1
+
+
+@pytest.mark.skipif(not RUN_INTEGRATION_TESTS, reason='Integration test')
+def test_load_refresh_tokens_catches_refresh_error(live_client_destructive):
+    tokens = live_client_destructive.login(refresh_tokens=True)
+    live_client_destructive.revoke_token_set(tokens)
+    tokens['auth.globus.org']['expires_at_seconds'] = 0
+    live_client_destructive.save_tokens(tokens)
+
+    # Should not raise sdk exception due to invalid grant:
+    # globus_sdk.exc.AuthAPIError: (400, 'Error', 'invalid_grant')
+    with pytest.raises(fair_research_login.LoadError):
+        live_client_destructive.load_tokens()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,23 @@ def mock_tokens():
 
 
 @pytest.fixture
+def refresh_authorizer_raises_invalid_grant(monkeypatch):
+
+    class MockResponse:
+        status_code = 400
+        headers = {'Content-Type': 'application/json'}
+
+        def json(self):
+            """(400, 'Error', 'invalid_grant')"""
+            return {'message': 'invalid_grant', 'code': 'Error'}
+
+    def err(*args, **kwargs):
+        raise globus_sdk.exc.AuthAPIError(MockResponse())
+    monkeypatch.setattr(globus_sdk.RefreshTokenAuthorizer,
+                        'check_expiration_time', err)
+
+
+@pytest.fixture
 def mock_tokens_underscores():
     return deepcopy(MOCK_TOKEN_SET_UNDERSCORES)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -108,11 +108,19 @@ def test_login_with_no_storage(mock_input, mock_webbrowser,
 
 
 def test_load_raises_scopes_mismatch(mem_storage, mock_tokens):
-    cli = NativeClient(client_id=str(uuid4()),
-                       token_storage=mem_storage)
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
     mem_storage.tokens = mock_tokens
     with pytest.raises(ScopesMismatch):
         cli.load_tokens(requested_scopes=['foo'])
+
+
+def test_load_tokens_with_invalid_refresh_token(
+        mem_storage, expired_tokens_with_refresh,
+        refresh_authorizer_raises_invalid_grant):
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    mem_storage.tokens = expired_tokens_with_refresh
+    with pytest.raises(TokensExpired):
+        cli.load_tokens()
 
 
 def test_load_accepts_string_or_iterable_requested_scopes(mem_storage,


### PR DESCRIPTION
Fix for #32. These changes also add some additional integration tests, in addition to allowing integration tests to be run by setting an environment variable (and not modifying code). 