### PR TITLE
Added changes/fixes for load_tokens

### DIFF
--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -102,7 +102,12 @@ class NativeClient(object):
         :return: None
         """
         if self.token_storage is not None:
-            return self.token_storage.write_tokens(tokens)
+            original_tks = self._load_raw_tokens()
+            for rs, ts in tokens.items():
+                # Set it if it doesn't exist
+                if original_tks.get(rs) != ts:
+                    original_tks[rs] = ts
+            return self.token_storage.write_tokens(original_tks)
         raise LoadError('No token_storage set on client.')
 
     def _load_raw_tokens(self):

--- a/fair_research_login/token_storage/__init__.py
+++ b/fair_research_login/token_storage/__init__.py
@@ -5,12 +5,12 @@ from fair_research_login.token_storage.configparser_token_storage import (
     ConfigParserTokenStorage, MultiClientTokenStorage
 )
 from fair_research_login.token_storage.storage_tools import (
-    flat_pack, flat_unpack, check_expired, check_scopes,
+    flat_pack, flat_unpack, check_expired, check_scopes, get_scopes
 )
 
 __all__ = [
     'JSONTokenStorage', 'ConfigParserTokenStorage',
     'MultiClientTokenStorage',
 
-    'flat_pack', 'flat_unpack', 'check_expired', 'check_scopes'
+    'flat_pack', 'flat_unpack', 'check_expired', 'check_scopes', 'get_scopes',
 ]

--- a/fair_research_login/token_storage/json_token_storage.py
+++ b/fair_research_login/token_storage/json_token_storage.py
@@ -20,7 +20,9 @@ class JSONTokenStorage(object):
         if not os.path.exists(self.filename):
             return None
         with open(self.filename) as fh:
-            return json.load(fh)
+            content = fh.read()
+            if content:
+                return json.loads(content)
 
     def clear_tokens(self):
         os.remove(self.filename)

--- a/fair_research_login/token_storage/storage_tools.py
+++ b/fair_research_login/token_storage/storage_tools.py
@@ -12,15 +12,20 @@ def check_expired(tokens):
         raise TokensExpired(resource_servers=expired)
 
 
-def check_scopes(tokens, requested_scopes):
+def get_scopes(tokens):
+    """Fetch scopes for tokens given a dict of tokens grouped by resource
+    server. """
     scopes = [tset['scope'].split() for tset in tokens.values()]
     # Get flattened list of scopes
-    loaded_scopes = [item for sublist in scopes for item in sublist]
-    if not set(requested_scopes).issubset(set(loaded_scopes)):
-        raise ScopesMismatch('Requested Scopes do not match loaded'
-                             ' Scopes for Globus Auth. \nRequested: {}\n'
-                             'Loaded: {}'.format(set(requested_scopes),
-                                                 set(loaded_scopes)))
+    return [item for sublist in scopes for item in sublist]
+
+
+def check_scopes(tokens, requested_scopes):
+    loaded_scopes = get_scopes(tokens)
+    diff = set(requested_scopes).difference(set(loaded_scopes))
+    if diff:
+        raise ScopesMismatch('Loaded Scopes missing Requested Scopes {}'
+                             ''.format(diff))
 
 
 def default_name_key(group_key, key):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,16 +48,18 @@ def mock_tokens_underscores():
 
 @pytest.fixture
 def mock_expired_tokens(mock_tokens):
-    for tset in mock_tokens.values():
+    tokens = deepcopy(mock_tokens)
+    for tset in tokens.values():
         tset['expires_at_seconds'] = 0
-    return mock_tokens
+    return tokens
 
 
 @pytest.fixture
 def expired_tokens_with_refresh(mock_expired_tokens):
-    for tset in mock_expired_tokens.values():
+    tokens = deepcopy(mock_expired_tokens)
+    for tset in tokens.values():
         tset['refresh_token'] = '<Mock Refresh Token>'
-    return mock_expired_tokens
+    return tokens
 
 
 @pytest.fixture

--- a/tests/unit/test_storage_classes.py
+++ b/tests/unit/test_storage_classes.py
@@ -28,6 +28,8 @@ def test_json_token_storage(mock_tokens, mock_revoke, monkeypatch):
     monkeypatch.setattr(os.path, 'exists', lambda x: True)
     mo = mock_open()
     with patch(BUILTIN_OPEN, mo):
+        from pprint import pprint
+        pprint(mock_tokens)
         cli.save_tokens(mock_tokens)
         written = ''.join([c[1][0] for c in mo().write.mock_calls])
     with patch(BUILTIN_OPEN, mock_open(read_data=written)):


### PR DESCRIPTION
These changes address the issue here #33. The main changes are to load_tokens(): 

* load_tokens() will now automatically exclude expired tokens
if called without a list of scopes and active tokens exist
* load_tokens() will only refresh tokens for the requested scopes
given.
* load_tokens() will only raise an expired token exception given
a list of requested scopes if one of the requested scopes is
expired
* load_tokens() will only return the list of tokens requested,
and will not return other tokens or attempt to refresh them
(but it will attempt to refresh tokens for loaded scopes).

Some additional changes:

* saving a new set of tokens will only overwrite tokens that have changed. 
* Fixed JSONTokenStorage Json Parse error from load_tokens() if file was empty

Added a bunch of tests to account for all the possible states above. 