### PR TITLE
Fix leaky tokens, add better verification, fix default_scopes bug

### DIFF
--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -153,7 +153,7 @@ class NativeClient(object):
         if not tokens:
             raise LoadError('No Tokens loaded')
 
-        if requested_scopes is not None:
+        if requested_scopes:
             # Support both string and list for requested scope. But ensure
             # it is a list.
             if isinstance(requested_scopes, str):
@@ -171,7 +171,7 @@ class NativeClient(object):
             expired = {rs: tokens[rs] for rs in te.resource_servers}
             # If the user requested scopes, one of their scopes expired by this
             # point and we need to let them know.
-            if requested_scopes is not None:
+            if requested_scopes:
                 raise
             # At this point, scopes expired but either were refreshable, or
             # the user didn't specify.

--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -5,7 +5,8 @@ import globus_sdk.exc
 from fair_research_login.code_handler import InputCodeHandler
 from fair_research_login.local_server import LocalServerCodeHandler
 from fair_research_login.token_storage import (
-    MultiClientTokenStorage, check_expired, check_scopes
+    MultiClientTokenStorage, check_expired, check_scopes, is_expired,
+    verify_token_group, TOKEN_GROUP_KEYS
 )
 from fair_research_login.exc import LoadError, TokensExpired
 
@@ -101,14 +102,33 @@ class NativeClient(object):
         :param tokens: globus_sdk.auth.token_response.OAuthTokenResponse.
         :return: None
         """
-        if self.token_storage is not None:
-            original_tks = self._load_raw_tokens()
-            for rs, ts in tokens.items():
-                # Set it if it doesn't exist
-                if original_tks.get(rs) != ts:
-                    original_tks[rs] = ts
-            return self.token_storage.write_tokens(original_tks)
-        raise LoadError('No token_storage set on client.')
+        if self.token_storage is None:
+            raise LoadError('No token_storage set on client.')
+
+        tokens = {rs: verify_token_group(ts) for rs, ts in tokens.items()}
+        original_tks = self._load_raw_tokens()
+        # These are the only items that should change in the case of an
+        # access token refresh or re-login with the same scope. In that case,
+        # We don't want to revoke the refresh_token but we DO want to test
+        # and refresh the old access token if it is still live.
+        ac_update = {'access_token', 'expires_at_seconds'}
+        for rs, ts in tokens.items():
+            # Fetch the items that have changed.
+            changed = {
+                item for item in TOKEN_GROUP_KEYS
+                if original_tks.get(rs, {}).get(item) != ts.get(item)
+            }
+            # Handle replacing ONLY the access token
+            if changed == ac_update:
+                if not is_expired(original_tks[rs]):
+                    self.client.oauth2_revoke_token(original_tks[rs])
+                original_tks[rs] = ts
+            # Replace everything and revoke the old tokens if they exist.
+            elif changed:
+                if original_tks.get(rs):
+                    self.revoke_token_set({rs: original_tks[rs]})
+                original_tks[rs] = ts
+        return self.token_storage.write_tokens(original_tks)
 
     def _load_raw_tokens(self):
         """
@@ -127,7 +147,8 @@ class NativeClient(object):
         exist.
         :return: Loaded tokens, or a LoadError if loading fails.
         """
-        tokens = self._load_raw_tokens()
+        tokens = {rs: verify_token_group(ts) for rs, ts in
+                  self._load_raw_tokens().items()}
 
         if not tokens:
             raise LoadError('No Tokens loaded')

--- a/fair_research_login/exc.py
+++ b/fair_research_login/exc.py
@@ -4,6 +4,16 @@ class LoginException(Exception):
     pass
 
 
+class InvalidTokenFormat(LoginException):
+    def __init__(self, message, code=None):
+        super(InvalidTokenFormat, self).__init__(message)
+        self.code = code
+
+    def __str__(self):
+        return '({}) {}'.format(super(InvalidTokenFormat, self).__str__(),
+                                self.code)
+
+
 class LocalServerError(LoginException):
     pass
 

--- a/fair_research_login/token_storage/__init__.py
+++ b/fair_research_login/token_storage/__init__.py
@@ -5,7 +5,8 @@ from fair_research_login.token_storage.configparser_token_storage import (
     ConfigParserTokenStorage, MultiClientTokenStorage
 )
 from fair_research_login.token_storage.storage_tools import (
-    flat_pack, flat_unpack, check_expired, check_scopes, get_scopes
+    flat_pack, flat_unpack, check_expired, check_scopes, get_scopes,
+    is_expired, verify_token_group, TOKEN_GROUP_KEYS, REQUIRED_TOKEN_KEYS
 )
 
 __all__ = [
@@ -13,4 +14,6 @@ __all__ = [
     'MultiClientTokenStorage',
 
     'flat_pack', 'flat_unpack', 'check_expired', 'check_scopes', 'get_scopes',
+    'is_expired', 'verify_token_group', 'TOKEN_GROUP_KEYS',
+    'REQUIRED_TOKEN_KEYS',
 ]

--- a/fair_research_login/token_storage/storage_tools.py
+++ b/fair_research_login/token_storage/storage_tools.py
@@ -1,7 +1,11 @@
 import time
+import copy
+import sys
 
 from fair_research_login.exc import (TokensExpired, ScopesMismatch,
                                      InvalidTokenFormat)
+
+string_types = str if sys.version_info.major == 3 else basestring
 
 TOKEN_GROUP_KEYS = {'access_token', 'refresh_token', 'expires_at_seconds',
                     'scope', 'token_type', 'resource_server'}
@@ -64,7 +68,7 @@ def verify_token_group(tokens):
         * invalid examples include: 'abc', '123abc'
 
     """
-    cleaned = tokens.copy()
+    cleaned = copy.deepcopy(tokens)
 
     if not isinstance(tokens, dict):
         raise InvalidTokenFormat('Tokens must be a dict.', code='not_dict')
@@ -80,7 +84,7 @@ def verify_token_group(tokens):
         ))
 
     for tp in ['access_token', 'scope', 'resource_server']:
-        if not isinstance(tokens.get(tp, ''), str):
+        if not isinstance(tokens.get(tp, ''), string_types):
             raise InvalidTokenFormat('{} must be a string.'.format(tp),
                                      code='invalid_type')
         cleaned[tp] = tokens[tp]
@@ -91,7 +95,7 @@ def verify_token_group(tokens):
     cleaned['token_type'] = 'Bearer'
 
     rt = tokens.get('refresh_token')
-    if rt and not isinstance(rt, str):
+    if rt and not isinstance(rt, string_types):
         raise InvalidTokenFormat('refresh_token must be a str or falsy',
                                  code='invalid_type')
     cleaned['refresh_token'] = rt or None

--- a/fair_research_login/token_storage/storage_tools.py
+++ b/fair_research_login/token_storage/storage_tools.py
@@ -5,7 +5,7 @@ import sys
 from fair_research_login.exc import (TokensExpired, ScopesMismatch,
                                      InvalidTokenFormat)
 
-string_types = str if sys.version_info.major == 3 else basestring
+string_types = str if sys.version_info.major == 3 else basestring  # noqa
 
 TOKEN_GROUP_KEYS = {'access_token', 'refresh_token', 'expires_at_seconds',
                     'scope', 'token_type', 'resource_server'}

--- a/tests/integration/test_client_refresh.py
+++ b/tests/integration/test_client_refresh.py
@@ -17,6 +17,7 @@ def test_refresh(live_client):
     tokens = live_client.login(refresh_tokens=True)
     for tset in tokens.values():
         tset['expires_at_seconds'] = 0
+        tset['access_token'] = 'foo'
     live_client.save_tokens(tokens)
     for rs, new_tokens in live_client.load_tokens().items():
         assert tokens[rs]['access_token'] != new_tokens['access_token']
@@ -54,6 +55,8 @@ def test_refresh_no_longer_works_after_logout(live_client_destructive):
 def test_load_live_token_when_another_inactive(live_client_destructive):
     tokens = live_client_destructive.login()
     tokens['auth.globus.org']['expires_at_seconds'] = 0
+    tokens['auth.globus.org']['access_token'] = 'fooey!'
+
     live_client_destructive.save_tokens(tokens)
     new_scope = ['urn:globus:auth:scope:transfer.api.globus.org:all']
     live_client_destructive.login(requested_scopes=new_scope)

--- a/tests/unit/data/invalid_tokens.json
+++ b/tests/unit/data/invalid_tokens.json
@@ -1,0 +1,90 @@
+[
+  {},
+  [],
+  {"foo": "bar"},
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org",
+    "foo": "bar"
+  },
+  {
+    "scope": "custom_scope another_scope",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": 123,
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+    {
+    "scope": "custom_scope",
+    "access_token": 123,
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+      {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": 1234,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Angry",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": "abc",
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": "123abc",
+    "resource_server": "resource.server.org"
+  }
+]

--- a/tests/unit/data/valid_tokens.json
+++ b/tests/unit/data/valid_tokens.json
@@ -1,0 +1,56 @@
+[
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope another_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": "<refresh_token>",
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": "",
+    "token_type": "Bearer",
+    "expires_at_seconds": 0,
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": "0",
+    "resource_server": "resource.server.org"
+  },
+  {
+    "scope": "custom_scope",
+    "access_token": "<token>",
+    "refresh_token": null,
+    "token_type": "Bearer",
+    "expires_at_seconds": 123.456,
+    "resource_server": "resource.server.org"
+  }
+]

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -4,6 +4,8 @@ import os
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 CONFIGPARSER_VALID_CFG = os.path.join(DATA_PATH, 'configparser_valid.cfg')
+VALID_TOKENS_FILE = os.path.join(DATA_PATH, 'valid_tokens.json')
+INVALID_TOKENS_FILE = os.path.join(DATA_PATH, 'invalid_tokens.json')
 
 DEFAULT_EXPIRE = int(time.time()) + 60 * 60 * 48
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -82,8 +82,8 @@ def test_save_new_tokens(mem_storage, mock_tokens):
     ts2 = {'transfer.api.globus.org': mock_tokens['transfer.api.globus.org']}
     cli.save_tokens(ts1)
     cli.save_tokens(ts2)
-    expected = ['auth.globus.org', 'transfer.api.globus.org']
-    assert list(mem_storage.tokens.keys()) == expected
+    expected = {'auth.globus.org', 'transfer.api.globus.org'}
+    assert set(mem_storage.tokens.keys()) == expected
 
 
 def test_save_overwrite_scope(mem_storage, mock_tokens, mock_revoke):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -86,7 +86,7 @@ def test_save_new_tokens(mem_storage, mock_tokens):
     assert list(mem_storage.tokens.keys()) == expected
 
 
-def test_save_overwrite_scope(mem_storage, mock_tokens):
+def test_save_overwrite_scope(mem_storage, mock_tokens, mock_revoke):
     cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
     mem_storage.tokens = {}
     ts1 = {'auth.globus.org': mock_tokens['auth.globus.org']}
@@ -95,6 +95,8 @@ def test_save_overwrite_scope(mem_storage, mock_tokens):
     # A new scope will come with new access tokens, so ensure those change too
     ts2['auth.globus.org']['access_token'] = 'new_acc'
     ts2['auth.globus.org']['refresh_token'] = 'new_ref'
+    ts2['auth.globus.org']['expires_at_seconds'] = (
+        ts2['auth.globus.org']['expires_at_seconds'] + 10)
     cli.save_tokens(ts1)
     cli.save_tokens(ts2)
     assert mem_storage.tokens['auth.globus.org']['scope'] == 'openid profile'
@@ -102,17 +104,31 @@ def test_save_overwrite_scope(mem_storage, mock_tokens):
     assert mem_storage.tokens['auth.globus.org']['refresh_token'] == 'new_ref'
 
 
-def test_save_overwrite_tokens(mem_storage, mock_tokens):
+def test_save_overwrite_tokens(mem_storage, mock_tokens, mock_revoke):
     cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
     mem_storage.tokens = {}
     ts1 = {'auth.globus.org': mock_tokens['auth.globus.org']}
     ts2 = {'auth.globus.org': ts1['auth.globus.org'].copy()}
     ts2['auth.globus.org']['access_token'] = 'new_acc'
     ts2['auth.globus.org']['refresh_token'] = 'new_ref'
+    ts2['auth.globus.org']['expires_at_seconds'] = (
+        ts2['auth.globus.org']['expires_at_seconds'] + 10)
     cli.save_tokens(ts1)
     cli.save_tokens(ts2)
     assert mem_storage.tokens['auth.globus.org']['access_token'] == 'new_acc'
     assert mem_storage.tokens['auth.globus.org']['refresh_token'] == 'new_ref'
+
+
+def test_login_revokes_old_live_token(mock_revoke, mock_tokens, mem_storage):
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    mem_storage.tokens = {'auth.globus.org': mock_tokens['auth.globus.org']}
+    new_tokens = {'auth.globus.org': mock_tokens['auth.globus.org'].copy()}
+    # Mock new login 10 seconds after the first one
+    new_tokens['auth.globus.org']['access_token'] = 'new_ac'
+    new_tokens['auth.globus.org']['expires_at_seconds'] += 10
+    cli.save_tokens(new_tokens)
+
+    assert mock_revoke.call_count == 1
 
 
 def test_client_token_calls_with_no_storage_raise_error(mock_tokens):


### PR DESCRIPTION
This adds a few fixes, with the main fix for #37.

Additionally, this adds better support for verifying token groups. In several places within the codebase, 'token_groups' are assumed to have various properties without actually checking for them, such as 'expires_at_seconds' and 'access_token' being properties that exist within a token dictionary. `save_tokens()` relies on this quite a bit, but it's good to have this generally for loading tokens too. The verification is fairly loose, and allows for some variance. See below for more info. 

Leaky tokens are fixed by revoking tokens that are slated to be overwritten. 

Added one additional fix where `login()` wouldn't respect default scopes set in `NativeClient()`. 