### PR TITLE
Fixed exception when using local server if user declined consent

### DIFF
--- a/fair_research_login/local_server.py
+++ b/fair_research_login/local_server.py
@@ -186,7 +186,10 @@ class RedirectHTTPServer(HTTPServer, object):
         # relevant Python issue discussing this behavior:
         # https://bugs.python.org/issue1360
         try:
-            return self._auth_code_queue.get(block=True, timeout=self.timeout)
+            resp = self._auth_code_queue.get(block=True, timeout=self.timeout)
+            if isinstance(resp, LocalServerError):
+                raise resp
+            return resp
         except queue.Empty:
             raise LocalServerError()
         finally:


### PR DESCRIPTION
If the user declined consent, error info would be sent down to the globus_sdk, resulting in an exception which makes no sense. This properly raises it at a point where it can be dealt with by code which expects the relevant LocalServerError, resulting in an exception which makes more sense and is easier to handle. 