### PR TITLE
Added more examples for edge cases

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -20,9 +20,25 @@ tokens = client.login(
     refresh_tokens=True,
 )
 
+# Calling login() twice will load tokens instead of initiating an oauth flow,
+# as long as the requested scopes match and the tokens have not expired.
+assert tokens == client.login(requested_scopes=['openid', 'profile'])
+
+# You can also load tokens explicitly. This will also load tokens if you have
+# done other logins
+assert tokens == client.load_tokens()
+# If you want to disregard other saved tokens
+assert tokens == client.load_tokens(requested_scopes=['openid', 'profile'])
+
+# Loading by scope is also supported
+tokens_by_scope = client.load_tokens_by_scope()
+assert set(tokens_by_scope.keys()) == {'openid', 'profile'}
+
 # Authorizers automatically choose a refresh token authorizer if possible,
 # and will automatically save new refreshed tokens when they expire.
 ac_authorizer = client.get_authorizers()['auth.globus.org']
+# Also supported
+ac_authorizer = client.get_authorizers_by_scope()['openid']
 
 # Example client usage:
 auth_cli = AuthClient(authorizer=ac_authorizer)

--- a/examples/handling_edge_cases.py
+++ b/examples/handling_edge_cases.py
@@ -1,0 +1,69 @@
+"""
+Here are some edge cases you may have to deal with in more complex scripts.
+"""
+import globus_sdk
+from fair_research_login import NativeClient, TokensExpired
+from fair_research_login.exc import LocalServerError
+
+# Register a Native App for a client_id at https://developers.globus.org
+client = NativeClient(client_id='7414f0b4-7d05-4bb6-bb00-076fa3f17cf5')
+
+"""
+Overwriting old live tokens results in revocation
+"""
+
+# Native Client revokes tokens when they're overwritten. It's generally bad to
+# depend on an old authorizer after a new login.
+# The following example will raise an error:
+
+client.login(requested_scopes=['openid', 'profile'])
+auth = client.get_authorizers()['auth.globus.org']
+# Requesting a token with new scopes will revoke the old token
+client.login(requested_scopes=['openid', 'profile', 'email'])
+# Using the old authorizer will result in an error
+globus_sdk.AuthClient(authorizer=auth).oauth2_userinfo()
+
+"""
+Handling when the user does not consent
+"""
+
+try:
+    client.login(
+        requested_scopes=['openid', 'profile'],
+        # Using the local server will essentially copy the auth code returned
+        # by Globus to a local webserver, where it can automatically be handed
+        # to the globus_sdk. The most likely error is Globus responds with an
+        # error instead of a code.
+        #
+        # Alternatively, with no local server, we simply wait for a code. The
+        # more likely case there is the user enters garbage which results in an
+        # invalid grant.
+        no_local_server=True,
+        )
+    print('Login Successful')
+except LocalServerError as lse:
+    # There was some problem with the local server, likely the user clicked
+    # "Decline" on the consents page
+    print('Login Unsuccessful: {}'.format(str(lse)))
+except globus_sdk.exc.AuthAPIError as aapie:
+    # Something went wrong with getting the auth code
+    print('Login Unsuccessful: {}'.format(aapie))
+
+"""
+Token Expiration
+"""
+
+# Let's start off by manually expiring some tokens
+client.save_tokens(
+    {'auth.globus.org': {
+        'scope': 'openid profile',
+        'access_token': '<fake_access_token>',
+        'expires_at_seconds': 0,
+        'resource_server': 'auth.globus.org',
+        }
+     }
+)
+try:
+    client.load_tokens(requested_scopes=['openid', 'profile'])
+except TokensExpired as te:
+    print('Load Failure, tokens expired for: {}'.format(te))


### PR DESCRIPTION
@rpwagner Not sure how useful these new docs are, so I could use a different perspective. The basic usage now shows loading tokens by scope. The new file, `handling_edge_cases.py` shows some additional common error checking developers can do for more refined tools. 