### PR TITLE
Fixed bug where expired tokens would not refresh with subset

### DIFF
--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -284,7 +284,7 @@ class NativeClient(object):
             expired = {rs: tokens[rs] for rs in te.resource_servers}
             # If the user requested scopes, one of their scopes expired by this
             # point and we need to let them know.
-            if requested_scopes:
+            if requested_scopes and not self._refreshable(expired):
                 raise
             # At this point, scopes expired but either were refreshable, or
             # the user didn't specify.

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -238,6 +238,20 @@ def test_client_token_refresh_with_tokens(expired_tokens_with_refresh,
         assert tset['access_token'] == '<Refreshed Access Token>'
 
 
+def test_client_token_refresh_with_requested_scope_subset(
+                                    mem_storage, expired_tokens_with_refresh,
+                                    mock_refresh_token_authorizer):
+    mem_storage.tokens = expired_tokens_with_refresh
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    tokens = cli.load_tokens(requested_scopes=['profile'])
+    assert tokens
+    for tset in mem_storage.tokens.values():
+        if tset['resource_server'] == 'auth.globus.org':
+            assert tset['access_token'] == '<Refreshed Access Token>'
+        else:
+            assert tset['access_token'] != '<Refreshed Access Token>'
+
+
 def test_client_get_authorizers(mock_tokens,
                                 mock_refresh_token_authorizer,
                                 mem_storage):


### PR DESCRIPTION
If a user requested a subset of tokens where the subset was expired
but refreshable, the client would not attempt to refresh the tokens
and would instead raise a tokens expired error. The fix now properly
refreshes the token subset and saves them for future use.