### PR TITLE
Fixed bug where login(no_local_server=True) didn't work

### DIFF
--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -184,10 +184,10 @@ class NativeClient(object):
         )
 
         for ch in self.code_handlers:
+            ch.set_context(self, **kwargs)
             if not ch.is_available():
                 log.info('{} code handler not available.'.format(ch))
                 continue
-            ch.set_context(self, **kwargs)
             with ch.start():
                 log.debug('Starting code handler {}'.format(ch))
                 self.client.oauth2_start_flow(

--- a/fair_research_login/version.py
+++ b/fair_research_login/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.0.dev0'
+__version__ = '0.2.0.dev1'

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -66,6 +66,17 @@ def test_remote_server_fallback(monkeypatch, mock_input, mock_webbrowser,
     assert InputCodeHandler.authenticate.called
 
 
+def test_login_no_local_server(monkeypatch, mock_input, mock_webbrowser,
+                               mock_token_response, mem_storage):
+    monkeypatch.setattr(LocalServerCodeHandler, 'authenticate', Mock())
+    monkeypatch.setattr(InputCodeHandler, 'authenticate', Mock())
+
+    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
+    cli.login(no_local_server=True)
+    assert not LocalServerCodeHandler.authenticate.called
+    assert InputCodeHandler.authenticate.called
+
+
 def test_code_handler_keyboard_interrupt_skip(monkeypatch, mock_input,
                                               mock_webbrowser, mem_storage,
                                               mock_token_response):


### PR DESCRIPTION
Context wasn't being set before the codehandlers ran, so options from
login weren't being respected.