### PR TITLE
fix: Include six as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 globus-sdk>=1.5.0
+six


### PR DESCRIPTION
Previously, this was a dependency on the globus-sdk. However, with
python2 being a year and a half past EOL, six is quickly being dropped
from many different packages, including the globus-sdk.

Until python2 is properly yanked from this package, six needs to be
included to avoid errors.

Note: https://github.com/fair-research/native-login/issues/40