### PR TITLE
fix: Tests being included in wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+PYTHON=python
+PIP=pip
+
+.PHONY: lint test
+lint:
+	flake8 fair_research_login
+test:
+	pytest
+
+.PHONY: test
+release: clean test
+	$(PYTHON) setup.py sdist
+	# Make wheel this way to avoid including tests in the resulting package
+	$(PIP) wheel --no-index --no-deps --wheel-dir dist dist/*.tar.gz
+
+.PHONY: upload
+upload: release
+	twine check dist/*
+	twine upload dist/*
+
+.PHONY: testupload
+testupload: release
+	twine check dist/*
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+.PHONY: clean
+clean:
+	rm -rf dist build *.egg-info


### PR DESCRIPTION
This includes a handy deploy script for running tests before uploading to PyPi. I'm quite bad at remembering that, so this is a nice addition. This also includes a fix for tests making their way into wheels, which previously happened any time `python setup.py bdist_wheel` was run regardless of the entry in MANIFEST.in. Using pip instead fixes this problem.

Fix for #56 