### PR TITLE
fix: Disallow Globus SDK version 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-globus-sdk>=1.5.0
+globus-sdk<3.0.0>=1.5.0
 six


### PR DESCRIPTION
The next release contains incompatible changes.