### PR TITLE
feat!: Remove save-revocation feature

### DIFF
--- a/fair_research_login/client.py
+++ b/fair_research_login/client.py
@@ -4,8 +4,8 @@ import globus_sdk
 from fair_research_login.code_handler import InputCodeHandler
 from fair_research_login.local_server import LocalServerCodeHandler
 from fair_research_login.token_storage import (
-    MultiClientTokenStorage, check_expired, check_scopes, is_expired,
-    verify_token_group, TOKEN_GROUP_KEYS, get_scopes
+    MultiClientTokenStorage, check_expired, check_scopes,
+    verify_token_group, get_scopes
 )
 from fair_research_login.exc import (
     LoadError, TokensExpired, TokenStorageDisabled, NoSavedTokens, AuthFailure
@@ -258,29 +258,10 @@ class NativeClient(object):
         if self.token_storage is None:
             raise TokenStorageDisabled()
 
-        tokens = {rs: verify_token_group(ts) for rs, ts in tokens.items()}
-        original_tks = self._load_raw_tokens()
-        # These are the only items that should change in the case of an
-        # access token refresh or re-login with the same scope. In that case,
-        # We don't want to revoke the refresh_token but we DO want to test
-        # and refresh the old access token if it is still live.
-        ac_update = {'access_token', 'expires_at_seconds'}
-        for rs, ts in tokens.items():
-            # Fetch the items that have changed.
-            changed = {
-                item for item in TOKEN_GROUP_KEYS
-                if original_tks.get(rs, {}).get(item) != ts.get(item)
-            }
-            # Handle replacing ONLY the access token
-            if changed == ac_update:
-                if not is_expired(original_tks[rs]):
-                    self.client.oauth2_revoke_token(original_tks[rs])
-                original_tks[rs] = ts
-            # Replace everything and revoke the old tokens if they exist.
-            elif changed:
-                if original_tks.get(rs):
-                    self.revoke_token_set({rs: original_tks[rs]})
-                original_tks[rs] = ts
+        new_tokens = {rs: verify_token_group(ts) for rs, ts in tokens.items()}
+        original_tks = {rs: verify_token_group(ts)
+                        for rs, ts, in self._load_raw_tokens().items()}
+        original_tks.update(new_tokens)
         return self.token_storage.write_tokens(original_tks)
 
     def _load_raw_tokens(self):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -206,18 +206,6 @@ def test_save_overwrite_tokens(mem_storage, mock_tokens, mock_revoke):
     assert mem_storage.tokens['auth.globus.org']['refresh_token'] == 'new_ref'
 
 
-def test_login_revokes_old_live_token(mock_revoke, mock_tokens, mem_storage):
-    cli = NativeClient(client_id=str(uuid4()), token_storage=mem_storage)
-    mem_storage.tokens = {'auth.globus.org': mock_tokens['auth.globus.org']}
-    new_tokens = {'auth.globus.org': mock_tokens['auth.globus.org'].copy()}
-    # Mock new login 10 seconds after the first one
-    new_tokens['auth.globus.org']['access_token'] = 'new_ac'
-    new_tokens['auth.globus.org']['expires_at_seconds'] += 10
-    cli.save_tokens(new_tokens)
-
-    assert mock_revoke.call_count == 1
-
-
 def test_client_token_calls_with_no_storage_raise_error(mock_tokens):
     cli = NativeClient(client_id=str(uuid4()), token_storage=None)
     with pytest.raises(LoadError):


### PR DESCRIPTION
Originally FRL had a feature to ensure that only tokens tracked
within token storage would be allowed to be live, and if those tokens
were replaced that the old ones would be revoked out of caution. This
causes unintended problems for any multiple instances of Globus SDK
service clients which attempt to use the same set of tokens, especially
in multi-threaded or multi-process environments. The first client to
renew its tokens will make the other clients tokens inoperable.

As far as I know, this feature always caught people by surprise, and
also hasn't provided tangible benefits, and so it will be removed.
Users can continue to revoke their current set of saved tokens by
calling logout(), or by going to https://app.globus.org/account/consents

BREAKING CHANGE: Old tokens replaced by new tokens from login will no
longer be revoked.