### PR TITLE
chore: bump correct test release

### DIFF
--- a/fair_research_login/version.py
+++ b/fair_research_login/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.0dev0'
+__version__ = '0.3.1dev0'


### PR DESCRIPTION
Original v0.3.0dev0 incorrectly moved the version backwards